### PR TITLE
drop old coordinates 'nlat' 'nlon' if present, rename z_w to z_w_top

### DIFF
--- a/pop_tools/xgcm_util.py
+++ b/pop_tools/xgcm_util.py
@@ -201,5 +201,11 @@ def to_xgcm_grid_dataset(ds, **kwargs):
             """to_xgcm_grid_dataset() function requires the `xgcm` package. \nYou can install it via PyPI or Conda"""
         )
     ds_new = relabel_pop_dims(ds)
+    if 'nlat' in ds_new.dims:
+        ds_new = ds_new.drop('nlat')
+    if 'nlon' in ds_new.dims:
+        ds_new = ds_new.drop('nlon')
+    if 'z_w_top' and 'z_w' in ds_new.dims:
+        ds_new = ds_new.drop('z_w_top').rename({'z_w': 'z_w_top'}) 
     grid = xgcm.Grid(ds_new, **kwargs)
     return grid, ds_new


### PR DESCRIPTION
'nlat' and 'nlon' are old coordinates and should not be included in the new ds.

If 'z_w_top' and 'z_w' are both present, drop 'z_w' and rename to 'z_w_top', to facilitate, e.g., multiplication with variables on those levels (the depths of 'z_w' and 'z_w_top' are identical). This could be done the other way around. 